### PR TITLE
update deps:

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure                          "1.5.1"]
-                 [cc.qbits/alia                                "1.0.0"]
-                 [cc.qbits/hayt                                "1.0.0"]
+                 [cc.qbits/alia                                "1.1.0"]
                  [com.datastax.cassandra/cassandra-driver-core "1.0.0"]]
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]

--- a/src/clojure/clojurewerkz/cassaforte/query.clj
+++ b/src/clojure/clojurewerkz/cassaforte/query.clj
@@ -43,7 +43,7 @@ Takes a table identifier and additional clause arguments:
 * where
 * table (optionaly using composition)"
   [table & clauses]
-  (into {:delete table :columns (keyword "")} clauses))
+  (into {:delete table} clauses))
 
 (def truncate-query verb/truncate)
 (def drop-keyspace-query verb/drop-keyspace)

--- a/test/clojurewerkz/cassaforte/cql_test.clj
+++ b/test/clojurewerkz/cassaforte/cql_test.clj
@@ -76,7 +76,7 @@
   (create-table :users_list
                 (column-definitions
                  {:name :varchar
-                  :test_list (keyword (list-type :varchar))
+                  :test_list (list-type :varchar)
                   :primary-key [:name]}))
 
   (testing "Inserting"
@@ -120,7 +120,7 @@
   (create-table :users_map
                 (column-definitions
                  {:name :varchar
-                  :test_map (keyword (map-type :varchar :varchar))
+                  :test_map (map-type :varchar :varchar)
                   :primary-key [:name]}))
 
   (testing "Inserting"
@@ -152,7 +152,7 @@
   (create-table :users_set
                 (column-definitions
                  {:name :varchar
-                  :test_set (keyword (set-type :varchar))
+                  :test_set (set-type :varchar)
                   :primary-key [:name]}))
 
   (testing "Inserting"


### PR DESCRIPTION
- removed hayt, it's already in alia 1.1.0, hayt is at 1.0.2 there already.
- cleaned up tests, no longer need to convert str coll types to keywords and delete columns to ":"
