### PR TITLE
run embedded server on higher ports to prevent potential conflicts with ...

### DIFF
--- a/resources/cassandra.yaml
+++ b/resources/cassandra.yaml
@@ -279,11 +279,11 @@ trickle_fsync: false
 trickle_fsync_interval_in_kb: 10240
 
 # TCP port, for commands and data
-storage_port: 7000
+storage_port: 17000
 
 # SSL port, for encrypted communication.  Unused unless enabled in
 # encryption_options
-ssl_storage_port: 7001
+ssl_storage_port: 17001
 
 # Address to bind to and tell other Cassandra nodes to connect to. You
 # _must_ change this if you want multiple nodes to be able to
@@ -309,17 +309,17 @@ listen_address: 127.0.0.1
 # same as the rpc_address. The port however is different and specified below.
 start_native_transport: true
 # port for the CQL native transport to listen for clients on
-native_transport_port: 9042
+native_transport_port: 19042
 # The minimum and maximum threads for handling requests when the native
 # transport is used. The meaning is those is similar to the one of
 # rpc_min_threads and rpc_max_threads, though the default differ slightly and
 # are the ones below:
-native_transport_min_threads: 2
-native_transport_max_threads: 16
+# native_transport_min_threads: 16
+# native_transport_max_threads: 128
 
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 # The address to bind the Thrift RPC service to -- clients connect
 # here. Unlike ListenAddress above, you *can* specify 0.0.0.0 here if
 # you want Thrift to listen on all interfaces.
@@ -329,7 +329,7 @@ start_rpc: true
 rpc_address: 127.0.0.1
 
 # port for Thrift to listen for clients on
-rpc_port: 9160
+rpc_port: 19160
 
 # enable or disable keepalive on rpc connections
 rpc_keepalive: true
@@ -363,8 +363,8 @@ rpc_server_type: sync
 # encouraged to set a maximum that makes sense for you in production, but do keep in mind that
 # rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
 #
-rpc_min_threads: 2
-rpc_max_threads: 16
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
 
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:


### PR DESCRIPTION
...local installs

This also disables the thrift listener making startup a bit quicker.
