### PR TITLE
Rename compile to qcompile to allow compilation with lein uberjar

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -252,7 +252,7 @@ reached.
   (let [renderer (if cql/*prepared-statement* cql/->prepared cql/->raw)]
     (renderer query-params)))
 
-(defn compile
+(defn qcompile
   "Compiles query from given `builder` and `query-params`"
   [query-params builder]
   (apply builder (flatten query-params)))

--- a/src/clojure/clojurewerkz/cassaforte/cql.clj
+++ b/src/clojure/clojurewerkz/cassaforte/cql.clj
@@ -8,7 +8,7 @@
 
 (defn ^:private execute-
   [query-params builder]
-  (let [rendered-query (client/render (client/compile query-params builder))]
+  (let [rendered-query (client/render (client/qcompile query-params builder))]
     (client/execute client/*default-session* rendered-query :prepared cql/*prepared-statement*)))
 
 ;;

--- a/src/clojure/clojurewerkz/cassaforte/multi/cql.clj
+++ b/src/clojure/clojurewerkz/cassaforte/multi/cql.clj
@@ -13,7 +13,7 @@
 
 (defn ^:private execute-
   [^Session session query-params builder]
-  (let [rendered-query (client/render (client/compile query-params builder))]
+  (let [rendered-query (client/render (client/qcompile query-params builder))]
     (client/execute session rendered-query :prepared cql/*prepared-statement*)))
 
 ;;


### PR DESCRIPTION
Refs Issue #11 - lein cannot build uberjar due to compile redefinition
