### PR TITLE
Allow clauses to be specified for each record in insert-batch

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/cql.clj
+++ b/src/clojure/clojurewerkz/cassaforte/cql.clj
@@ -127,9 +127,12 @@
   (execute- query-params query/insert-query))
 
 (defn insert-batch
-  "Performs a batch insert (inserts multiple records into a table at the same time)"
+  "Performs a batch insert (inserts multiple records into a table at the same time).
+  To specify additional clauses for a record (such as where or using), wrap that record
+  and the clauses in a vector"
   [table records]
-  (let [query (->> (map #(query/insert-query table %) records)
+  (let [query (->> records
+                   (map (comp (partial apply (partial query/insert-query table)) flatten vector))
                    (apply query/queries)
                    query/batch-query
                    client/render-query)]

--- a/src/clojure/clojurewerkz/cassaforte/multi/cql.clj
+++ b/src/clojure/clojurewerkz/cassaforte/multi/cql.clj
@@ -132,9 +132,12 @@
   (execute- session query-params query/insert-query))
 
 (defn insert-batch
-  "Performs a batch insert (inserts multiple records into a table at the same time)"
+  "Performs a batch insert (inserts multiple records into a table at the same time)
+  To specify additional clauses for a record (such as where or using), wrap that record
+  and the clauses in a vector"
   [^Session session table records]
-  (let [query (->> (map #(query/insert-query table %) records)
+  (let [query (->> records
+                   (map (comp (partial apply (partial query/insert-query table)) flatten vector))
                    (apply query/queries)
                    query/batch-query
                    client/render-query)]

--- a/test/clojurewerkz/cassaforte/cql_test.clj
+++ b/test/clojurewerkz/cassaforte/cql_test.clj
@@ -14,6 +14,22 @@
      (is (= r (first (select :users))))
      (truncate :users))))
 
+(deftest insert-batch-test
+  (th/test-combinations
+   (let [input [[{:name "Alex" :city "Munich" :age (int 19)} (using :ttl 350)]
+                [{:name "Alex" :city "Munich" :age (int 19)} (using :ttl 350)]]]
+     (insert-batch :users input)
+     (is (= (first (first input)) (first (select :users))))
+     (truncate :users))))
+
+(deftest insert-batch-plain-test
+  (th/test-combinations
+   (let [input [{:name "Alex" :city "Munich" :age (int 19)}
+                {:name "Alex" :city "Munich" :age (int 19)}]]
+     (insert-batch :users input)
+     (is (= (first input) (first (select :users))))
+     (truncate :users))))
+
 (deftest update-test
   (testing "Simple updates"
     (th/test-combinations

--- a/test/clojurewerkz/cassaforte/multi/cql_test.clj
+++ b/test/clojurewerkz/cassaforte/multi/cql_test.clj
@@ -14,6 +14,22 @@
      (is (= r (first (select th/session :users))))
      (truncate th/session :users))))
 
+(deftest insert-batch-test
+  (th/test-combinations
+   (let [input [[{:name "Alex" :city "Munich" :age (int 19)} (using :ttl 350)]
+                [{:name "Alex" :city "Munich" :age (int 19)} (using :ttl 350)]]]
+     (insert-batch th/session :users input)
+     (is (= (first (first input)) (first (select th/session :users))))
+     (truncate th/session :users))))
+
+(deftest insert-batch-plain-test
+  (th/test-combinations
+   (let [input [{:name "Alex" :city "Munich" :age (int 19)}
+                {:name "Alex" :city "Munich" :age (int 19)}]]
+     (insert-batch th/session :users input)
+     (is (= (first input) (first (select th/session :users))))
+     (truncate th/session :users))))
+
 (deftest update-test
   (testing "Simple updates"
     (th/test-combinations


### PR DESCRIPTION
The old syntax is still supported.
An additional clause (e.g. where or using) can be specified
individually for each record.  That record should be wrapped
in a vector (any seq really).  Records without additional
clauses are stilled supported and don't need to be wrapped.
