### PR TITLE
trivial fix for get-hosts on 2.0.x

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -322,7 +322,7 @@ reached.
          {:datacenter (.getDatacenter host)
           :address    (.getHostAddress (.getAddress host))
           :rack       (.getRack host)
-          :is-up      (.isUp (.getMonitor host))})
+          :is-up      (.isUp host)})
        (-> session
            .getCluster
            .getMetadata


### PR DESCRIPTION
It seems getMonitor was removed on 2.0.x,

i am using this version on 2.0.3 (latest atm) and it is ok.
