### PR TITLE
Check for an invalid *default-session*.

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -326,7 +326,10 @@ reached.
   [& args]
   (let [[^Session session query & {:keys [prepared]}] (if (= (type (first args)) Session)
                                                         args
-                                                        (cons *default-session* args))
+                                                        (if (bound? #'*default-session*)
+                                                          (cons *default-session* args)
+                                                          (throw
+                                                           (IllegalArgumentException. "Default session is invalid."))))
         ^Statement statement (if prepared
                                (if (coll? query)
                                  (build-statement (prepare session (first query))


### PR DESCRIPTION
Otherwise execute fails with a distant error with an irrelevant
stacktrace.

This cannot break backwards compatibility because it failed with the
exact same exception, it just catches it earlier and inserts a more
helpful error message.
