### PR TITLE
shutdown renamed to close in cassandra-driver-core

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -298,15 +298,15 @@ reached.
    1-arity version receives Session, and shuts it down. It doesn't shut down all other sessions
    on same cluster."
   ([]
-     (.shutdown *default-session*)
-     (.shutdown *default-cluster*))
+     (.close *default-session*)
+     (.close *default-cluster*))
   ([^Session session]
-     (.shutdown session)))
+     (.close session)))
 
 (defn shutdown-cluster
   "Shut down the Cluster"
   [^Cluster cluster]
-  (.shutdown cluster))
+  (.close cluster))
 
 (defn render-query
   "Renders compiled query"

--- a/test/clojurewerkz/cassaforte/client_test.clj
+++ b/test/clojurewerkz/cassaforte/client_test.clj
@@ -1,0 +1,18 @@
+(ns clojurewerkz.cassaforte.client-test
+  (:require [clojurewerkz.cassaforte.test-helper :as th]
+            [clojurewerkz.cassaforte.client :as client]
+            [clojure.test :refer :all]))
+
+(use-fixtures :each th/initialize!)
+
+(let [s (client/connect! ["127.0.0.1"])]
+  (deftest test-disconnect
+    (let [cluster (.getCluster s)]
+      (is (= (.isClosed s) false))
+      (client/disconnect! s)
+      (is (= (.isClosed s) true))
+      (is (= (.isClosed cluster) false))
+      (client/shutdown-cluster cluster)
+      (is (= (.isClosed cluster) true)))))
+
+


### PR DESCRIPTION
shutdown method was renamed to close in cassandra-driver-core 2.0.0.
Made the fix to the client.clj and added also test to make sure this
would not break again.
