### PR TITLE
Client-to-node encryption and Kerberos auth support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
   :dependencies [[org.clojure/clojure                          "1.6.0"]
                  [cc.qbits/hayt                                "1.4.1"
                   :exclusions [org.flatland/useful]]
-                 [com.datastax.cassandra/cassandra-driver-core "2.0.2"]]
+                 [com.datastax.cassandra/cassandra-driver-core "2.0.2"]
+                 [com.datastax.cassandra/cassandra-driver-dse "2.0.2"]]
   :source-paths      ["src/clojure"]
   :java-source-paths ["src/java"]
   :profiles       {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}


### PR DESCRIPTION
This pull request adds support for client-to-node encryption and kerberos auth, as well as a shortcut for building SSLOptions object (which should work for most cases).

I was working off the official guide (http://www.datastax.com/dev/blog/accessing-secure-dse-clusters-with-cql-native-protocol) with a couple of changes, namely:
- Using keystore to init both `KeyManager` and `TrustManager`. It works for my test cluster and should work in general case.
- Re-using the keystore object.
- Not specifying the source of randomness, which makes it fall back to the default implementation. I’m not sure if this is the right thing to do, so maybe it should be changed to use `SecureRandom` explicitly.

Also I’m not sure how to test this properly. Setting up encryption and kerberos is pretty painful.
