### PR TITLE
Add disconnect! to close sessions and shutdown cluster preventing accidental program hangs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
                                         [org.clojure/tools.trace           "0.7.6"]]}}
   :aliases        {"all" ["with-profile" "dev:dev,1.4:dev,1.5:dev,1.7:dev,master"]}
   :test-selectors {:focus   :focus
+                   :client  :client
                    :cql     :cql
                    :schema  :schema
                    :stress  :stress

--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -146,6 +146,11 @@
   [^Session session]
   (.close session))
 
+(defn disconnect!
+  "Shuts the cluster and session down.  If you have other sessions, use the safe `disconnect` function instead."
+  [^Session session]
+  (.close (.getCluster session)))
+
 (defn shutdown-cluster
   "Shuts down provided cluster"
   [^Cluster cluster]

--- a/test/clojurewerkz/cassaforte/client_test.clj
+++ b/test/clojurewerkz/cassaforte/client_test.clj
@@ -2,14 +2,26 @@
   (:require [clojurewerkz.cassaforte.client :as client]
             [clojure.test :refer :all]))
 
-(let [s (client/connect ["127.0.0.1"])]
-  (deftest test-disconnect
-    (let [cluster (.getCluster s)]
-      (is (= (.isClosed s) false))
-      (client/disconnect s)
-      (is (= (.isClosed s) true))
-      (is (= (.isClosed cluster) false))
-      (client/shutdown-cluster cluster)
-      (is (= (.isClosed cluster) true)))))
+
+(deftest ^:client test-disconnect
+  (let [s (client/connect ["127.0.0.1"])
+        cluster (.getCluster s)]
+    (is (= (.isClosed s) false))
+    (client/disconnect s)
+    (is (= (.isClosed s) true))
+    (is (= (.isClosed cluster) false))
+    (client/shutdown-cluster cluster)
+    (is (= (.isClosed cluster) true))))
+
+
+(deftest ^:client test-disconnect!
+  (let [s (client/connect ["127.0.0.1"])
+        cluster (.getCluster s)]
+    (is (= (.isClosed s) false))
+    (is (= (.isClosed cluster) false))
+    (client/disconnect! s)
+    (is (= (.isClosed s) true))
+    (is (= (.isClosed cluster) true))))
+
 
 


### PR DESCRIPTION
If you call connect and get a session object, calling disconnect on it later on will result in your program hanging as the session and cluster have relations to each other that can't get garbage collected.  For those who aren't managing their cluster objects themselves, disconnect! will clean up their cluster and session for them.
