### PR TITLE
Moved keyspace back to options

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -124,14 +124,18 @@
 (defn ^Session connect
   "Connects to the Cassandra cluster. Use `build-cluster` to build a cluster."
   ([hosts]
-     (.connect (build-cluster {:hosts hosts})))
-  ([hosts opts]
-     (let [keyspace (:keyspace opts)
-           opts (dissoc opts :keyspace)
-           c (build-cluster (merge opts {:hosts hosts}))]
-       (if keyspace
-        (.connect c (name keyspace))
-        (.connect c)))))
+   (.connect (build-cluster {:hosts hosts})))
+  ([hosts keyspace-or-opts]
+    (if (string? keyspace-or-opts)
+      (connect hosts keyspace-or-opts {})
+      (let [keyspace (:keyspace keyspace-or-opts)
+            opts (dissoc keyspace-or-opts :keyspace)]
+        (if keyspace
+          (connect hosts keyspace opts)
+          (.connect (-> opts (merge {:hosts hosts}) build-cluster))))))
+  ([hosts keyspace opts]
+   (let [c (build-cluster (merge opts {:hosts hosts}))]
+     (.connect c (name keyspace)))))
 
 (defn ^Session connect-with-uri
   ([^String uri]

--- a/test/clojurewerkz/cassaforte/client_test.clj
+++ b/test/clojurewerkz/cassaforte/client_test.clj
@@ -54,7 +54,16 @@
       (is (= TokenAwarePolicy (class (.. cluster getConfiguration getPolicies getLoadBalancingPolicy))))
       (client/disconnect session)))
 
-  (testing "Connect with keyspace"
+  (testing "Connect with keyspace, without options"
+    (let [session (client/connect ["127.0.0.1"] "system")
+          cluster (.getCluster session)]
+      (is (= false (.isClosed session)))
+      (is (= false (.isClosed cluster)))
+      (is (= "system" (.getLoggedKeyspace session)))
+      (is (= TokenAwarePolicy (class (.. cluster getConfiguration getPolicies getLoadBalancingPolicy))))
+      (client/disconnect session)))
+
+  (testing "Connect with keyspace in options"
     (let [session (client/connect ["127.0.0.1"] {:keyspace "system"})
           cluster (.getCluster session)]
       (is (= false (.isClosed session)))
@@ -72,8 +81,17 @@
       (is (= RoundRobinPolicy (class (.. cluster getConfiguration getPolicies getLoadBalancingPolicy))))
       (client/disconnect session)))
 
-  (testing "Connect with both options and keyspace"
+  (testing "Connect with options and keyspace (in options)"
     (let [session (client/connect ["127.0.0.1"] {:load-balancing-policy (RoundRobinPolicy.) :keyspace "system"})
+          cluster (.getCluster session)]
+      (is (= false (.isClosed session)))
+      (is (= false (.isClosed cluster)))
+      (is (= "system" (.getLoggedKeyspace session)))
+      (is (= RoundRobinPolicy (class (.. cluster getConfiguration getPolicies getLoadBalancingPolicy))))
+      (client/disconnect session)))
+
+  (testing "Connect with options and keyspace (separate args)"
+    (let [session (client/connect ["127.0.0.1"] "system" {:load-balancing-policy (RoundRobinPolicy.)})
           cluster (.getCluster session)]
       (is (= false (.isClosed session)))
       (is (= false (.isClosed cluster)))


### PR DESCRIPTION
Fixes #57 

I’m not sure if it’s alright to break core APIs this late in the dev cycle, so if this is not acceptable, I’ll try to work around it somehow.
