### PR TITLE
Make cql/iterate-table terminate when the last loaded chunk is empty

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/cql.clj
+++ b/src/clojure/clojurewerkz/cassaforte/cql.clj
@@ -304,4 +304,6 @@
      (lazy-cat c
                (let [last-pk    (map #(get (last c) %) partition-key)
                      next-chunk (load-chunk session table partition-key chunk-size last-pk)]
-                 (iterate-table session table partition-key chunk-size next-chunk)))))
+                 (if (empty? next-chunk)
+                   []
+                   (iterate-table session table partition-key chunk-size next-chunk))))))

--- a/test/clojurewerkz/cassaforte/iterate_table_test.clj
+++ b/test/clojurewerkz/cassaforte/iterate_table_test.clj
@@ -10,14 +10,27 @@
   (use-fixtures :each (fn [f]
                         (th/with-temporary-keyspace s f)))
 
-  (deftest test-iterate-table
-    (let [n 100000]
-      (dotimes [i n]
-        (insert s :users {:name (str "name_" i) :city (str "city" i) :age (int i)}))
+(deftest test-iterate-table-with-natural-iteration-termination
+  (let [n 100000]
+    (dotimes [i n]
+      (insert s :users {:name (str "name_" i) :city (str "city" i) :age (int i)}))
 
       (let [res (group-by :name
-                          (take n (iterate-table s :users :name 1024)))]
+                          (iterate-table s :users :name 16384))]
         (dotimes [i n]
           (let [item (first (get res (str "name_" i)))]
             (is (= {:name (str "name_" i) :city (str "city" i) :age (int i)}
-                   item))))))))
+                   item)))))))
+
+(deftest test-iterate-table-with-explicit-limit
+  (let [n 100]
+    (dotimes [i n]
+      (insert s :users {:name (str "name_" i) :city (str "city" i) :age (int i)}))
+
+    (let [res (group-by :name
+                        (take (- n 20)
+                              (iterate-table s :users :name 1024)))]
+      (dotimes [i n]
+        (let [item (first (get res (str "name_" i)))]
+          (is (= {:name (str "name_" i) :city (str "city" i) :age (int i)}
+                 item))))))))


### PR DESCRIPTION
Fixes #74.
