### PR TITLE
Added new API to get all the tables for given keyspace

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/cql.clj
+++ b/src/clojure/clojurewerkz/cassaforte/cql.clj
@@ -312,6 +312,14 @@
            (q/where {:keyspace_name (name ks)
                      :columnfamily_name (name table)}))))
 
+
+(defn describe-tables
+  "Returns all the tables description, taken from system.schema_columnfamilies "
+  [^Session session ks]
+  (select session :system.schema_columnfamilies
+          (q/where {:keyspace_name (name ks)
+                    })))
+
 (defn describe-columns
   "Returns table columns description, taken from `system.schema_columns`."
   [^Session session ks table]

--- a/test/clojure/clojurewerkz/cassaforte/schema_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/schema_test.clj
@@ -61,7 +61,11 @@
                   (if-not-exists))
 
     (let [td      (describe-table s "new_cql_keyspace" "people")
+          tables (describe-tables s "new_cql_keyspace")
           columns (describe-columns s "new_cql_keyspace" "people")]
+
+      (is (= "people" (get-in tables [0 :columnfamily_name])))
+
       (is (or
            (= "org.apache.cassandra.db.marshal.DateType"
               (get-in columns [0 :validator]))


### PR DESCRIPTION
I am creating a cassandra admin tool and I am using cassaforte, There I need to get all the tables of a Keyspace, since this API does not present, added the same named describe-tables.

Please add this in master branch.

Thanks
Sougata 