### PR TITLE
Upgrade driver to 3.0.0-beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ matrix:
   exclude:
     - jdk: oraclejdk7
         env: CASSANDRA_VERSION=3.0.1
+    - jdk: oraclejdk7
         env: CASSANDRA_VERSION=2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 lein: lein2
-sudo: false
+sudo: required
 before_install:
   - "ulimit -u 4096"
 script: ./bin/ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: ./bin/ci.sh
 env:
   - CASSANDRA_VERSION=2.0.13
   - CASSANDRA_VERSION=2.1.9
+  - CASSANDRA_VERSION=2.2.4
   - CASSANDRA_VERSION=3.0.1
 jdk:
   - oraclejdk7
@@ -15,3 +16,8 @@ branches:
   only:
     - master
     - 2.0.x-stable
+matrix:
+  exclude:
+    - jdk: oraclejdk7
+        env: CASSANDRA_VERSION=3.0.1
+        env: CASSANDRA_VERSION=2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ branches:
 matrix:
   exclude:
     - jdk: oraclejdk7
-        env: CASSANDRA_VERSION=3.0.1
+      env: CASSANDRA_VERSION=3.0.1
     - jdk: oraclejdk7
-        env: CASSANDRA_VERSION=2.2.4
+      env: CASSANDRA_VERSION=2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ sudo: required
 before_install:
   - "ulimit -u 4096"
 script: ./bin/ci.sh
+env:
+  - CASSANDRA_VERSION=2.0.13
+  - CASSANDRA_VERSION=2.1.9
+  - CASSANDRA_VERSION=3.0.1
 jdk:
   - oraclejdk7
   - oraclejdk8
 branches:
   only:
     - master
-    - 1.3.x-stable
+    - 2.0.x-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: clojure
 lein: lein2
+sudo: false
 before_install:
   - "ulimit -u 4096"
 script: ./bin/ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 lein: lein2
-sudo: required
+sudo: false
 before_install:
   - "ulimit -u 4096"
 script: ./bin/ci.sh

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CLUSTER_NAME      := cassaforte_cluster
 CASSANDRA_VERSION := binary:2.1.3
 
 maybe_install_ccm:
-	test -s ccm || { git clone https://github.com/pcmanus/ccm.git $(CCM_DIR) ; cd $(CCM_DIR) ; sudo ./setup.py install ; }
+	test -s ccm || { git clone https://github.com/pcmanus/ccm.git $(CCM_DIR) ; cd $(CCM_DIR) ; git checkout ccm-2.0.3 ; sudo ./setup.py install ; }
 
 prepare_tmp_dir:
 	rm -fr $(CONFIG_DIR) ;\

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CLUSTER_NAME      := cassaforte_cluster
 CASSANDRA_VERSION := binary:2.1.3
 
 maybe_install_ccm:
-	test -s ccm || pip install ccm
+	test -s ccm || { git clone https://github.com/pcmanus/ccm.git $(CCM_DIR) ; cd $(CCM_DIR) ; sudo ./setup.py install ; }
 
 prepare_tmp_dir:
 	rm -fr $(CONFIG_DIR) ;\

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CLUSTER_NAME      := cassaforte_cluster
 CASSANDRA_VERSION := binary:2.1.3
 
 maybe_install_ccm:
-	test -s ccm || { git clone https://github.com/pcmanus/ccm.git $(CCM_DIR) ; cd $(CCM_DIR) ; sudo ./setup.py install ; }
+	test -s ccm || pip install ccm
 
 prepare_tmp_dir:
 	rm -fr $(CONFIG_DIR) ;\

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-CCM_DIR           := ./ccm
 CONFIG_DIR        := /tmp/cassaforte-data
 CLUSTER_NAME      := cassaforte_cluster
 CASSANDRA_VERSION := binary:2.1.3
 
 maybe_install_ccm:
-	test -s ccm || { git clone https://github.com/pcmanus/ccm.git $(CCM_DIR) ; cd $(CCM_DIR) ; git checkout ccm-2.0.3 ; sudo ./setup.py install ; }
+	which ccm || test -s ~/.local/bin/ccm || pip install --user ccm
 
 prepare_tmp_dir:
 	rm -fr $(CONFIG_DIR) ;\
@@ -26,4 +25,4 @@ stop_cluster:
 
 .PHONY: clean
 clean:
-	rm -fr $(CCM_DIR)
+	pip uninstall ccm

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,9 +1,3 @@
-make start_one_node_cluster                                 && \
-lein2 all do clean, test, clean                             && \
-make stop_cluster                                           && \
-make start_one_node_cluster CASSANDRA_VERSION=binary:2.0.13 && \
-lein2 do test, clean                                        && \
-make stop_cluster                                           && \
-make start_one_node_cluster CASSANDRA_VERSION=binary:3.0.1  && \
-lein2 do test, clean                                        && \
-make stop_cluster
+make start_one_node_cluster CASSANDRA_VERSION=binary:$CASSANDRA_VERSION && \
+lein2 all do clean, test, clean                                         && \
+make stop_cluster                                                       && \

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,9 +1,9 @@
 make start_one_node_cluster                                 && \
-lein2 all do clean, test                                    && \
+lein2 all do clean, test, clean                             && \
 make stop_cluster                                           && \
 make start_one_node_cluster CASSANDRA_VERSION=binary:2.0.13 && \
-lein2 test                                                  && \
+lein2 do test, clean                                        && \
 make stop_cluster                                           && \
 make start_one_node_cluster CASSANDRA_VERSION=binary:3.0.1  && \
-lein2 test                                                  && \
+lein2 do test, clean                                        && \
 make stop_cluster

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,8 +1,8 @@
-make start_one_node_cluster                                 && \ 
-lein2 all do clean, test                                    && \ 
-make stop_cluster                                           && \ 
-make start_one_node_cluster CASSANDRA_VERSION=binary:2.0.13 && \ 
-lein2 test                                                  && \ 
+make start_one_node_cluster                                 && \
+lein2 all do clean, test                                    && \
+make stop_cluster                                           && \
+make start_one_node_cluster CASSANDRA_VERSION=binary:2.0.13 && \
+lein2 test                                                  && \
 make stop_cluster                                           && \
 make start_one_node_cluster CASSANDRA_VERSION=binary:3.0.1  && \
 lein2 test                                                  && \

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -1,3 +1,3 @@
 make start_one_node_cluster CASSANDRA_VERSION=binary:$CASSANDRA_VERSION && \
 lein2 all do clean, test, clean                                         && \
-make stop_cluster                                                       && \
+make stop_cluster

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -3,4 +3,7 @@ lein2 all do clean, test                                    && \
 make stop_cluster                                           && \ 
 make start_one_node_cluster CASSANDRA_VERSION=binary:2.0.13 && \ 
 lein2 test                                                  && \ 
+make stop_cluster                                           && \
+make start_one_node_cluster CASSANDRA_VERSION=binary:3.0.1  && \
+lein2 test                                                  && \
 make stop_cluster

--- a/project.clj
+++ b/project.clj
@@ -30,8 +30,7 @@
                                                 ;; test/development
                                                 [org.clojure/tools.namespace "0.2.10"]
                                                 [org.clojure/test.check      "0.7.0"]
-                                                [com.gfredericks/test.chuck  "0.1.17"]
-                                                ]}}
+                                                [com.gfredericks/test.chuck  "0.1.17"]]}}
   :aliases           {"all" ["with-profile" "dev:dev,1.6:dev,master"]}
   :test-selectors    {:focus   :focus
                       :client  :client

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
   :license           {:name "Eclipse Public License"
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies      [[org.clojure/clojure                          "1.7.0"]
-                      [com.datastax.cassandra/cassandra-driver-core "2.1.6"]
-                      [com.datastax.cassandra/cassandra-driver-dse  "2.1.6"]
+                      [com.datastax.cassandra/cassandra-driver-core "3.0.0-beta1"]
+                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0-beta1"]
                       [org.clojure/core.match                       "0.3.0-alpha4"]]
   :aot [clojurewerkz.cassaforte.query]
   :source-paths      ["src/clojure"]

--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -149,7 +149,7 @@
     (when load-balancing-policy
       (.withLoadBalancingPolicy builder load-balancing-policy))
     (when compression
-      (.withCompression (select-compression compression)))
+      (.withCompression builder (select-compression compression)))
     (when ssl
       (.withSSL builder (build-ssl-options ssl)))
     (when ssl-options
@@ -251,11 +251,10 @@
   ;; TODO: matching
   (if (map? values)
     (.bind statement (to-array (vals values)))
-    (.bind statement (to-array values))
-    ))
+    (.bind statement (to-array values))))
 
 (defn prepare
-  [session statement]
+  [^Session session  statement]
   (.prepare session statement))
 
 ;; (defn execute-async)
@@ -276,7 +275,7 @@
                                      default-timestamp]}]
    (let [^Statement built-statement (build-statement query)]
      (when default-timestamp
-       (.setDefaultTimestamp built-statement))
+       (.setDefaultTimestamp built-statement default-timestamp))
      (when enable-tracing
        (.enableTracing built-statement))
      (when fetch-size

--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -123,8 +123,7 @@
            ssl-options
            kerberos
            protocol-version
-           compression]
-    :or {protocol-version 2}}]
+           compression]}]
   (let [^Cluster$Builder builder        (Cluster/builder)
         ^PoolingOptions pooling-options (PoolingOptions.)]
     (when port

--- a/src/clojure/clojurewerkz/cassaforte/client.clj
+++ b/src/clojure/clojurewerkz/cassaforte/client.clj
@@ -25,7 +25,7 @@
             [clojurewerkz.cassaforte.conversion :as conv])
   (:import [com.datastax.driver.core Statement ResultSet ResultSetFuture Host Session Cluster
             Cluster$Builder SimpleStatement PreparedStatement BoundStatement HostDistance PoolingOptions
-            SSLOptions ProtocolOptions$Compression]
+            SSLOptions ProtocolOptions$Compression ProtocolVersion]
            [com.datastax.driver.auth DseAuthProvider]
            [com.google.common.util.concurrent ListenableFuture Futures FutureCallback]
            [java.net URI]
@@ -130,7 +130,7 @@
     (when port
       (.withPort builder port))
     (when protocol-version
-      (.withProtocolVersion builder protocol-version))
+      (.withProtocolVersion builder (ProtocolVersion/fromInt protocol-version)))
     (when credentials
       (.withCredentials builder (:username credentials) (:password credentials)))
     (when connections-per-host

--- a/src/clojure/clojurewerkz/cassaforte/policies.clj
+++ b/src/clojure/clojurewerkz/cassaforte/policies.clj
@@ -16,7 +16,7 @@
   "Consistency levels, retry policies, reconnection policies, etc"
   (:import [com.datastax.driver.core ConsistencyLevel]
            [com.datastax.driver.core.policies
-            LoadBalancingPolicy DCAwareRoundRobinPolicy RoundRobinPolicy TokenAwarePolicy
+            LoadBalancingPolicy DCAwareRoundRobinPolicy$Builder RoundRobinPolicy TokenAwarePolicy
             LoggingRetryPolicy DefaultRetryPolicy DowngradingConsistencyRetryPolicy FallthroughRetryPolicy
             RetryPolicy ConstantReconnectionPolicy ExponentialReconnectionPolicy]))
 
@@ -35,7 +35,7 @@
    Like round-robin but over the nodes located in the same datacenter.
    Nodes from other datacenters will be tried only if all requests to local nodes fail."
   [^String local-dc]
-  (DCAwareRoundRobinPolicy. local-dc))
+  (.. (DCAwareRoundRobinPolicy$Builder.) (withLocalDc local-dc) (build)))
 
 (defn token-aware-policy
   "Takes a load balancing policy and makes it token-aware"

--- a/src/clojure/clojurewerkz/cassaforte/query/types.clj
+++ b/src/clojure/clojurewerkz/cassaforte/query/types.clj
@@ -51,5 +51,5 @@
 ;; FIXME should be using cluster instance and cluster.metadata.newTupleType instead
 (defn tuple-of
   [^ProtocolVersion protocol-version types values]
-  (.newValue (TupleType/of protocol-version CodecRegistry/DEFAULT_INSTANCE ((into-array (map #(get primitive-types %) types))))
+  (.newValue (TupleType/of protocol-version CodecRegistry/DEFAULT_INSTANCE (into-array (map #(get primitive-types %) types)))
              (object-array values)))

--- a/src/clojure/clojurewerkz/cassaforte/query/types.clj
+++ b/src/clojure/clojurewerkz/cassaforte/query/types.clj
@@ -1,5 +1,5 @@
 (ns clojurewerkz.cassaforte.query.types
-  (:import [com.datastax.driver.core TupleType DataType]))
+  (:import [com.datastax.driver.core TupleType DataType ProtocolVersion CodecRegistry]))
 
 ;;
 ;; Types
@@ -48,7 +48,8 @@
   (DataType/map (get primitive-types key-type)
                 (get primitive-types value-type)))
 
+;; FIXME should be using cluster instance and cluster.metadata.newTupleType instead
 (defn tuple-of
-  [types values]
-  (.newValue (TupleType/of (into-array (map #(get primitive-types %) types)))
+  [^ProtocolVersion protocol-version types values]
+  (.newValue (TupleType/of protocol-version CodecRegistry/DEFAULT_INSTANCE ((into-array (map #(get primitive-types %) types))))
              (object-array values)))

--- a/test/clojure/clojurewerkz/cassaforte/conversion_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/conversion_test.clj
@@ -1,7 +1,41 @@
 (ns clojurewerkz.cassaforte.conversion-test
   (:import [java.util HashMap ArrayList HashSet])
   (:require [clojurewerkz.cassaforte.conversion :refer :all]
+            [clojurewerkz.cassaforte.client :as client]
+
+            [clojurewerkz.cassaforte.test-helper :refer [^Session *session* with-keyspace]]
             [clojure.test :refer :all]))
+
+(use-fixtures :each with-keyspace)
+
+(deftest ints-and-strings
+  (client/execute *session* "create table test1(id int primary key, val varchar)")
+  (client/execute *session* "insert into test1(id, val) values (1, 'whatsup')")
+  (is (= [{:id 1 :val "whatsup"}]
+         (to-clj (client/execute *session* "select * from test1")))))
+(deftest list-of-ints
+  (client/execute *session* "create table test1(id int primary key, val list<int>)")
+  (client/execute *session* "insert into test1(id, val) values (1, [5, 6, 7])")
+  (is (= [{:id 1 :val [5 6 7]}]
+         (to-clj (client/execute *session* "select * from test1")))))
+(deftest set-of-doubles
+  (client/execute *session* "create table test1(id int primary key, val set<double>)")
+  (client/execute *session* "insert into test1(id, val) values (1, {5.0, 6.5, 7.314})")
+  (is (= [{:id 1 :val #{5.0 6.5 7.314}}]
+         (to-clj (client/execute *session* "select * from test1")))))
+(deftest map-of-stuff
+  (client/execute *session* "create table test1(id int primary key, val map<timestamp, inet>)")
+  (client/execute *session* "insert into test1(id, val) values (1, {
+                      '2015-10-10 00:00:00+0000' : '127.0.0.1',
+                      '2015-11-11 11:11:11+0000' : '8.8.8.8'})")
+  (is (= [{:id 1 :val {#inst "2015-10-10T00:00:00.000-00:00" (java.net.InetAddress/getByName "127.0.0.1")
+                       #inst "2015-11-11T11:11:11.000-00:00" (java.net.InetAddress/getByName "8.8.8.8")}}]
+         (to-clj (client/execute *session* "select * from test1")))))
+(deftest nils-everywhere
+  (client/execute *session* "create table test1(id int primary key, val1 int, val2 text, val3 list<inet>)")
+  (client/execute *session* "insert into test1(id, val1, val2, val3) values (1, null, null, null)")
+  (is (= [{:id 1 :val1 nil :val2 nil :val3 []}]
+         (to-clj (client/execute *session* "select * from test1")))))
 
 (deftest conversion-test
   (testing "Map Conversion"

--- a/test/clojure/clojurewerkz/cassaforte/cql_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/cql_test.clj
@@ -321,7 +321,9 @@
     (let [xs  (select *session* :events
                       (unix-timestamp-of :created_at)
                       (limit 5))
-          ts' (get (first xs) (keyword "unixTimestampOf(created_at)"))]
+          ts' (or
+                (get (first xs) (keyword "unixTimestampOf(created_at)"))
+                (get (first xs) (keyword "system.unixtimestampof(created_at)")))]
       (is (> ts' ts)))))
 
 (deftest test-timeuuid-dateof

--- a/test/clojure/clojurewerkz/cassaforte/query_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/query_test.clj
@@ -164,7 +164,7 @@
                           (unix-timestamp-of :created_at)
                           (limit 5))))
 
-  (is (renders-to "INSERT INTO events(created_at,message) VALUES (now(),'Message 1');"
+  (is (renders-to "INSERT INTO events (created_at,message) VALUES (now(),'Message 1');"
                   (insert :events
                           {:created_at (now)
                            :message    "Message 1"})))
@@ -219,19 +219,19 @@
                        (limit 42)))))
 
 (deftest test-insert-query
-  (is (renders-to "INSERT INTO foo(asd) VALUES ('bsd');"
+  (is (renders-to "INSERT INTO foo (asd) VALUES ('bsd');"
                   (insert :foo
                           {"asd" "bsd"})))
-  (is (renders-to "INSERT INTO foo(asd) VALUES ('bsd');"
-                  (insert :foo
-                          {"asd" "bsd"})))
-
-  (is (renders-to "INSERT INTO foo(asd) VALUES ('bsd');"
+  (is (renders-to "INSERT INTO foo (asd) VALUES ('bsd');"
                   (insert :foo
                           {"asd" "bsd"})))
 
+  (is (renders-to "INSERT INTO foo (asd) VALUES ('bsd');"
+                  (insert :foo
+                          {"asd" "bsd"})))
 
-  (is (renders-to "INSERT INTO foo(a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;"
+
+  (is (renders-to "INSERT INTO foo (a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;"
                   (insert :foo
                           (array-map "a"          123
                                      "b"          (java.net.InetAddress/getByName "127.0.0.1")
@@ -240,7 +240,7 @@
                           (using (array-map :timestamp 42
                                             :ttl       24)))))
 
-  (is (renders-to "INSERT INTO foo(a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;"
+  (is (renders-to "INSERT INTO foo (a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;"
                   (insert :foo
                           (array-map "a"          123
                                      "b"          (java.net.InetAddress/getByName "127.0.0.1")
@@ -249,35 +249,35 @@
                           (using (array-map :timestamp 42
                                             :ttl       24)))))
 
-  (is (renders-to "INSERT INTO foo(a,b) VALUES ({2,3,4},3.4) USING TIMESTAMP 42 AND TTL 24;"
+  (is (renders-to "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4) USING TIMESTAMP 42 AND TTL 24;"
                   (insert :foo
                           (array-map "a" (sorted-set 2 3 4)
                                      "b" 3.4)
                           (using (array-map :timestamp 42
                                             :ttl       24)))))
 
-  (is (renders-to "INSERT INTO foo(a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;"
+  (is (renders-to "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;"
                   (insert :foo
                           (array-map :a (sorted-set 2 3 4)
                                      :b 3.4)
                           (using (array-map :ttl       ?
                                             :timestamp ?)))))
 
-  (is (renders-to "INSERT INTO foo(c,a,b) VALUES (123,{2,3,4},3.4) USING TIMESTAMP 42;"
+  (is (renders-to "INSERT INTO foo (c,a,b) VALUES (123,{2,3,4},3.4) USING TIMESTAMP 42;"
                   (insert :foo
                           (array-map :c 123
                                      :a (sorted-set 2 3 4)
                                      :b 3.4)
                           (using {:timestamp 42}))))
 
-  (is (renders-to "INSERT INTO foo(k,x) VALUES (0,1) IF NOT EXISTS;";
+  (is (renders-to "INSERT INTO foo (k,x) VALUES (0,1) IF NOT EXISTS;";
                   (insert :foo
                           (array-map :k 0
                                      :x 1)
                           (if-not-exists))))
 
 
-  (is (renders-to "INSERT INTO foo(k,x) VALUES (0,(1));";
+  (is (renders-to "INSERT INTO foo (k,x) VALUES (0,(1));";
                   (insert :foo
                           (array-map :k 0
                                      :x (tuple-of [:int] [(int 1)]))))))
@@ -415,9 +415,9 @@
                   (truncate :a :b))))
 
 (deftest test-batch
-  (is (renders-to (str "BEGIN BATCH INSERT INTO foo(asd) VALUES ('bsd');"
-                       "INSERT INTO foo(asd) VALUES ('bsd');"
-                       "INSERT INTO foo(asd) VALUES ('bsd');"
+  (is (renders-to (str "BEGIN BATCH INSERT INTO foo (asd) VALUES ('bsd');"
+                       "INSERT INTO foo (asd) VALUES ('bsd');"
+                       "INSERT INTO foo (asd) VALUES ('bsd');"
                        "APPLY BATCH;")
                   (batch
                    (queries

--- a/test/clojure/clojurewerkz/cassaforte/query_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/query_test.clj
@@ -1,5 +1,6 @@
 (ns clojurewerkz.cassaforte.query-test
-  (:import [com.datastax.driver.core.utils Bytes])
+  (:import  [com.datastax.driver.core ProtocolVersion]
+            [com.datastax.driver.core.utils Bytes])
   (:require [clojure.test                  :refer :all]
             [clojurewerkz.cassaforte.query :refer :all]))
 
@@ -280,7 +281,7 @@
   (is (renders-to "INSERT INTO foo (k,x) VALUES (0,(1));";
                   (insert :foo
                           (array-map :k 0
-                                     :x (tuple-of [:int] [(int 1)]))))))
+                                     :x (tuple-of (ProtocolVersion/fromInt 3) [:int] [(int 1)]))))))
 
 (deftest update-test
   (is (renders-to "UPDATE foo USING TIMESTAMP 42 SET a=12,b=[3,2,1],c=c+3 WHERE k=2;"

--- a/test/clojure/clojurewerkz/cassaforte/schema_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/schema_test.clj
@@ -2,8 +2,7 @@
   (:refer-clojure :exclude [update])
   (:require [clojurewerkz.cassaforte.test-helper :refer [*session* with-keyspace]]
             [clojurewerkz.cassaforte.cql         :refer :all]
-            [clojure.test                        :refer :all]
-            ))
+            [clojure.test                        :refer :all]))
 
 (defn changes-by
   [f f2 n]

--- a/test/clojure/clojurewerkz/cassaforte/schema_test.clj
+++ b/test/clojure/clojurewerkz/cassaforte/schema_test.clj
@@ -42,13 +42,13 @@
 (deftest test-create-alter-keyspace
   (alter-keyspace *session* "new_cql_keyspace"
                   (with {:durable-writes false
-                         :replication    {"class" "NetworkTopologyStrategy"
-                                          "dc1"   1
-                                          "dc2"   2}}))
+                         :replication    (array-map "class" "NetworkTopologyStrategy"
+                                                    "dc1"   1)}))
   (let [res (describe-keyspace *session* "new_cql_keyspace")]
     (is (= "new_cql_keyspace" (:keyspace_name res)))
     (is (= false (:durable_writes res)))
-    (is (= "{\"dc2\":\"2\",\"dc1\":\"1\"}" (:strategy_options res)))))
+    (is (= "{\"dc1\":\"1\"}" (:strategy_options res)))
+    (is (= "{\"dc1\":\"1\"}" (:strategy_options res)))))
 
 (deftest test-create-table-with-indices
   (create-table *session* :people

--- a/test/clojure/clojurewerkz/cassaforte/test_helper.clj
+++ b/test/clojure/clojurewerkz/cassaforte/test_helper.clj
@@ -72,8 +72,7 @@
       (catch Exception e
         (throw e))
       (finally
-        (client/disconnect! session)))
-    ))
+        (client/disconnect! session)))))
 
 (defn with-keyspace
   [f]


### PR DESCRIPTION
Changes that were immediately necessary to make cassaforte work with 3.0.0 (and support C* 3.0 as a result).

Most notable breaking change is signature change for `types/tuple-of` since it now requires... things.

Also fixed a couple of bugs as I went.