### PR TITLE
fixes dependencies and policies to use with Cassandra 3.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
-(defproject clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"
+(defproject clojurewerkz/cassaforte "3.0.0-gorillalabs-alpha2-SNAPSHOT"
   :min-lein-version  "2.5.1"
   :description       "A Clojure client for Apache Cassandra"
   :url               "http://clojurecassandra.info"
   :license           {:name "Eclipse Public License"
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies      [[org.clojure/clojure                          "1.7.0"]
-                      [com.datastax.cassandra/cassandra-driver-core "3.0.0"]
-                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0"]
+                      [com.datastax.cassandra/cassandra-driver-core "3.0.2"]
+                      [com.datastax.cassandra/cassandra-driver-dse "3.0.0-rc1"]
                       [org.clojure/core.match                       "0.3.0-alpha4"]]
   :aot [clojurewerkz.cassaforte.query]
   :source-paths      ["src/clojure"]

--- a/src/clojure/clojurewerkz/cassaforte/policies.clj
+++ b/src/clojure/clojurewerkz/cassaforte/policies.clj
@@ -16,7 +16,7 @@
   "Consistency levels, retry policies, reconnection policies, etc"
   (:import [com.datastax.driver.core ConsistencyLevel]
            [com.datastax.driver.core.policies
-            LoadBalancingPolicy DCAwareRoundRobinPolicy$Builder RoundRobinPolicy TokenAwarePolicy
+            LoadBalancingPolicy DCAwareRoundRobinPolicy DCAwareRoundRobinPolicy$Builder RoundRobinPolicy TokenAwarePolicy
             LoggingRetryPolicy DefaultRetryPolicy DowngradingConsistencyRetryPolicy FallthroughRetryPolicy
             RetryPolicy ConstantReconnectionPolicy ExponentialReconnectionPolicy]))
 


### PR DESCRIPTION
Hi,

I'm trying to run my client using cassaforte against Cassandra 3.4. However, I failed using the versions provided on Clojars. Thus I forked and patched my own version.

Initially, I wasn't able to build / run your version, so I made these little tweaks.

My problems were twofold:

* DSE isn't yet publically available in 3.0.0, only in 3.0.0-rc1, so my dependency resolution broke.
* policies.clj is missing an import to DCAwareRoundRobinPolicy, it only imported the inner "Builder"-class and breaks on line 38, when DCAwareRoundRobinPolicy/builder (instance, not class) is referred to.

These problems are fixed and I'm able to connect. However, I did not run any other tests yet, not even simple queries. This will follow next.

I'd really, really appreciate a "Cassaforte to use with Cassandra 3.x" release, hope this brings us a little closer.

Happy hacking,

Chris