### PR TITLE
Getting rid of core.match

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"
+(defproject clojurewerkz/cassaforte "3.0.0-alpha3-SNAPSHOT"
   :min-lein-version  "2.5.1"
   :description       "A Clojure client for Apache Cassandra"
   :url               "http://clojurecassandra.info"
@@ -6,8 +6,7 @@
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies      [[org.clojure/clojure                          "1.8.0"]
                       [com.datastax.cassandra/cassandra-driver-core "3.0.2"]
-                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0-rc1"]
-                      [org.clojure/core.match                       "0.3.0-alpha4"]]
+                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0-rc1"]]
   :aot [clojurewerkz.cassaforte.query]
   :source-paths      ["src/clojure"]
   :test-paths        ["test/clojure" "test/java"]

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
-(defproject clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"
+(defproject clojurewerkz/cassaforte "3.0.0-gorillalabs-alpha2-SNAPSHOT"
   :min-lein-version  "2.5.1"
   :description       "A Clojure client for Apache Cassandra"
   :url               "http://clojurecassandra.info"
   :license           {:name "Eclipse Public License"
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies      [[org.clojure/clojure                          "1.7.0"]
-                      [com.datastax.cassandra/cassandra-driver-core "3.0.0"]
-                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0"]
+                      [com.datastax.cassandra/cassandra-driver-core "3.0.2"]
+                      [com.datastax.cassandra/cassandra-driver-dse "3.0.0-rc1"]
                       [org.clojure/core.match                       "0.3.0-alpha4"]]
   :aot [clojurewerkz.cassaforte.query]
   :source-paths      ["src/clojure"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurewerkz/cassaforte "3.0.0-gorillalabs-alpha2-SNAPSHOT"
+(defproject clojurewerkz/cassaforte "3.0.0-alpha2-SNAPSHOT"
   :min-lein-version  "2.5.1"
   :description       "A Clojure client for Apache Cassandra"
   :url               "http://clojurecassandra.info"

--- a/src/clojure/clojurewerkz/cassaforte/policies.clj
+++ b/src/clojure/clojurewerkz/cassaforte/policies.clj
@@ -16,7 +16,7 @@
   "Consistency levels, retry policies, reconnection policies, etc"
   (:import [com.datastax.driver.core ConsistencyLevel]
            [com.datastax.driver.core.policies
-            LoadBalancingPolicy DCAwareRoundRobinPolicy$Builder RoundRobinPolicy TokenAwarePolicy
+            LoadBalancingPolicy DCAwareRoundRobinPolicy DCAwareRoundRobinPolicy$Builder RoundRobinPolicy TokenAwarePolicy
             LoggingRetryPolicy DefaultRetryPolicy DowngradingConsistencyRetryPolicy FallthroughRetryPolicy
             RetryPolicy ConstantReconnectionPolicy ExponentialReconnectionPolicy]))
 


### PR DESCRIPTION
Hi,

core.match is only alpha something and obviously it's broken in newer Clojure versions, meaning stuff is broken in cassaforte also.
As core.match is not under active development anymore I got rid of it, which was relatively easy.

Now, my branch builds. However, still some tests (in clojurewerkz.cassaforte.schema-test) are failing, but I think that's because stuff was changing in CQL. Will check that later on, but that'll take some more days, as I'm really busy right now.

Hope you find the versioning ok and can merge stuff automatically. Otherwise feel free to change things ;) here before merging, I invited you as collaborator on this fork.

Cheers,

Chris