### PR TITLE
removes org.clojure/core.match

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,7 @@
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies      [[org.clojure/clojure                          "1.8.0"]
                       [com.datastax.cassandra/cassandra-driver-core "3.0.2"]
-                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0-rc1"]
-                      [org.clojure/core.match                       "0.3.0-alpha4"]]
+                      [com.datastax.cassandra/cassandra-driver-dse  "3.0.0-rc1"]]
   :aot [clojurewerkz.cassaforte.query]
   :source-paths      ["src/clojure"]
   :test-paths        ["test/clojure" "test/java"]


### PR DESCRIPTION
core.match clashes with [org.clojure/tools.reader "0.10.0"]. So, you could either fix dependencies in the project using cassaforte or just remove the core.match dependency, which is a no-brainer.

see #125 for more details.
