### PR TITLE
Re-adding the to-bytes conversion function

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/conversion.clj
+++ b/src/clojure/clojurewerkz/cassaforte/conversion.clj
@@ -49,3 +49,10 @@
                                       :address    (.getHostAddress (.getAddress host))
                                       :rack       (.getRack host)})
     :else                          java-val))
+
+(defn #^bytes to-bytes
+  [^ByteBuffer byte-buffer]
+  (let [bytes (byte-array (.remaining byte-buffer))]
+    (.get byte-buffer bytes 0 (count bytes))
+    bytes))
+


### PR DESCRIPTION
For blob output, but you don't want to do this conversion for every blob (hence why not adding it in the `to-clj` function above). Some of those will be other datatypes kept in Cassandra as Blob types, so the user should be allowed to change them later.