### PR TITLE
[#135] Typo preventing use with Clojure 1.9+

### DIFF
--- a/src/clojure/clojurewerkz/cassaforte/query.clj
+++ b/src/clojure/clojurewerkz/cassaforte/query.clj
@@ -94,7 +94,7 @@ Takes a table identifier and additional clause arguments:
      * `key` - key to paginate on
      * `last-key` - last seen value of the key, next chunk of results will contain all keys that follow that value
      * `per-page` - how many results per page"
-  ([& {:keys [key last-key per-page where] :or {:page 0}}]
+  ([& {:keys [key last-key per-page where] :or {per-page 0}}]
      {:limit per-page
       :where (if last-key
                (conj (vec where) [> key last-key])


### PR DESCRIPTION
- Just guessing at the original intention here.
- Confirmed that this seems to be the only change necessary for 1.9+ support.